### PR TITLE
Clone, not copy, the TLS config which is sync.Locker

### DIFF
--- a/proxy.go
+++ b/proxy.go
@@ -255,9 +255,9 @@ func CheckTLSHandshake(ctx context.Context, connect *http.Request, backend strin
 	}
 
 	target := url.URL{Host: connect.RequestURI}
-	config := TLS
+	config := TLS.Clone()
 	config.ServerName = target.Hostname()
-	conn := tls.Client(i, &config)
+	conn := tls.Client(i, config)
 	defer func() {
 		_ = conn.Close()
 	}()


### PR DESCRIPTION
Should I clone the TLS config that is sync.Locker instead of copying it?